### PR TITLE
Fix bug where bracket view crashed when selecting different season

### DIFF
--- a/components/PlayoffsBracket.tsx
+++ b/components/PlayoffsBracket.tsx
@@ -104,7 +104,7 @@ function PlayoffsBracket({ data, league }: Props): JSX.Element {
   };
   const renderRound = (round, index) => (
     <Round key={index}>
-      <h2>{`Round ${index + 1}`}</h2>
+      <h2>{round.length === 1 ? "Finals" : `Round ${index + 1}`}</h2>
       {round.map(serie => renderSerie(serie))}
     </Round>
   );

--- a/components/PlayoffsBracket.tsx
+++ b/components/PlayoffsBracket.tsx
@@ -46,10 +46,10 @@ function PlayoffsBracket({ data, league }: Props): JSX.Element {
   }, []);
 
   useEffect(() => {
-    setIsLoading(isLoadingAssets || !data || !teamData);
-  }, [isLoadingAssets, data, teamData]);
+    setIsLoading(isLoadingAssets || !teamData);
+  }, [isLoadingAssets, teamData]);
 
-  if (teamError || isLoading) return <PlayoffsBracketSkeleton isError={teamError} />;
+  if (teamError || isLoading || !data) return <PlayoffsBracketSkeleton isError={teamError} />;
 
   const renderSerie = (serie: PlayoffsSerie) => {
     const isInternationalLeague = league === "iihf" || league === "wjc";
@@ -124,8 +124,8 @@ function PlayoffsBracketSkeleton({ isError }: {
 }): JSX.Element {
   const fakeArray = (length) => new Array(length).fill(0);
 
-  const renderSkeletonSeries = () => (
-    <Series>
+  const renderSkeletonSeries = (i) => (
+    <Series key={i}>
       <SeriesTeam color={'#CCC'} isDark={false} lost={false}>
         <div style={{ marginLeft: '5px' }}></div>
         <Skeleton width={45} height={45} />
@@ -149,16 +149,16 @@ function PlayoffsBracketSkeleton({ isError }: {
     <Bracket>
       <Round>
         <Skeleton width={150} height={30} />
-        {fakeArray(4).map(() => renderSkeletonSeries())}
+        {fakeArray(4).map((_, i) => renderSkeletonSeries(i))}
       </Round>
       <Round>
         <Skeleton width={150} height={30} />
-        {fakeArray(2).map(() => renderSkeletonSeries())}
+        {fakeArray(2).map((_, i) => renderSkeletonSeries(i))}
       </Round>
       <Round>
         <Skeleton width={150} height={30} />
         <Series>
-          {renderSkeletonSeries()}
+          {renderSkeletonSeries(0)}
         </Series>
       </Round>
     </Bracket>

--- a/pages/[league]/standings.tsx
+++ b/pages/[league]/standings.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 function Standings({ league }: Props): JSX.Element {
   const [display, setDisplay] = useState('league');
-  const [seasonType, setSeasonType] = useState<SeasonType>('Playoffs');
+  const [seasonType, setSeasonType] = useState<SeasonType>('Regular Season');
   const [isPlayoffs, setIsPlayoffs] = useState(false);
   const [isLoadingView, setIsLoadingView] = useState(true);
   const { data, isLoading } = useStandings(league, display, isPlayoffs);

--- a/pages/[league]/standings.tsx
+++ b/pages/[league]/standings.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 function Standings({ league }: Props): JSX.Element {
   const [display, setDisplay] = useState('league');
-  const [seasonType, setSeasonType] = useState<SeasonType>('Regular Season');
+  const [seasonType, setSeasonType] = useState<SeasonType>('Playoffs');
   const [isPlayoffs, setIsPlayoffs] = useState(false);
   const [isLoadingView, setIsLoadingView] = useState(true);
   const { data, isLoading } = useStandings(league, display, isPlayoffs);


### PR DESCRIPTION
Issue was the the `useEffect` which determines the `isLoading` state doesn't react fast enough to `data` becoming undefined, making the component try one more render but with an undefined object. And that just doesn't work very well. Moving the `data` check outside `useEffect` solved the problem.