### PR TITLE
Use WCAG library to determine text colors on team(s) page

### DIFF
--- a/pages/[league]/team/[teamid].tsx
+++ b/pages/[league]/team/[teamid].tsx
@@ -4,6 +4,7 @@ import { GetServerSideProps } from 'next';
 import Error from 'next/error';
 import styled from 'styled-components';
 import { NextSeo } from 'next-seo';
+import tinycolor from 'tinycolor2';
 
 // import useSWR from 'swr';
 import Header from '../../../components/Header';
@@ -87,25 +88,11 @@ function TeamPage({
           alt={`${name} logo`}
         />
         <TeamInfoContainer>
-          <TeamName
-            color={
-              ['Anchorage', 'Kelowna', 'Maine', 'Anaheim'].indexOf(location) !=
-              -1
-                ? '#FFFFFF'
-                : colors.text
-            }
-          >
+          <TeamName bright={tinycolor(colors.primary).isDark()}>
             <span className="first">{nameDetails.first}</span>
             <span className="second">{nameDetails.second}</span>
           </TeamName>
-          <TeamHeaderStats
-            color={
-              ['Anchorage', 'Kelowna', 'Maine', 'Anaheim'].indexOf(location) !=
-              -1
-                ? '#FFFFFF'
-                : colors.text
-            }
-          >
+          <TeamHeaderStats bright={tinycolor(colors.primary).isDark()}>
             <span>
               {stats.wins} - {stats.losses} -{' '}
               {stats.overtimeLosses + stats.shootoutLosses}
@@ -217,14 +204,14 @@ const TeamInfoContainer = styled.div`
   }
 `;
 
-const TeamName = styled.h1<{ color: string }>`
-  color: ${({ color }) => color};
+const TeamName = styled.h1<{ bright: boolean }>`
+  color: ${({ bright, theme }) => bright ? theme.colors.grey100 : theme.colors.grey900};
   span {
     display: block;
   }
 
   span.first {
-    font-weight: 300;
+    font-weight: 400;
     letter-spacing: 0.1rem;
   }
 
@@ -235,9 +222,9 @@ const TeamName = styled.h1<{ color: string }>`
   }
 `;
 
-const TeamHeaderStats = styled.h3<{ color: string }>`
-  color: ${({ color }) => color};
-  font-weight: 100;
+const TeamHeaderStats = styled.h3<{ bright: boolean }>`
+  color: ${({ bright, theme }) => bright ? theme.colors.grey100 : theme.colors.grey900};
+  font-weight: 400;
   font-size: 1.1rem;
 
   span {

--- a/pages/[league]/team/index.tsx
+++ b/pages/[league]/team/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { NextSeo } from 'next-seo';
 import styled from 'styled-components';
+import tinycolor from 'tinycolor2';
 import { Team } from '../../..';
 import Header from '../../../components/Header';
 import Link from '../../../components/LinkWithSeason';
@@ -41,15 +42,7 @@ function index({ league, teamlist }: Props): JSX.Element {
                     .join('_')}.svg`)}
                   alt={`${team.name} logo`}
                 />
-                <TeamName
-                  color={
-                    ['Kelowna', 'Maine', 'Anaheim', 'Anchorage'].indexOf(
-                      team.location
-                    ) != -1
-                      ? '#FFFFFF'
-                      : team.colors.text
-                  }
-                >
+                <TeamName bright={tinycolor(team.colors.primary).isDark()}>
                   <span className="first">{team.nameDetails.first}</span>
                   <span className="second">{team.nameDetails.second}</span>
                 </TeamName>
@@ -107,8 +100,8 @@ const TeamLogo = styled.img`
   margin: 0 5%;
 `;
 
-const TeamName = styled.h2<{ color: string }>`
-  color: ${({ color }) => color};
+const TeamName = styled.h2<{ bright: boolean }>`
+  color: ${({ bright, theme }) => bright ? theme.colors.grey100 : theme.colors.grey900};
 
   span {
     display: block;

--- a/pages/[league]/team/index.tsx
+++ b/pages/[league]/team/index.tsx
@@ -108,7 +108,7 @@ const TeamName = styled.h2<{ bright: boolean }>`
   }
 
   span.first {
-    font-weight: 300;
+    font-weight: 400;
     letter-spacing: 0.1rem;
   }
 


### PR DESCRIPTION
Have the library do the job for us so we don't have to manually change this with new teams and/or brandings.
Also bumped the font weight up a bit to make the text a little easier to read.

Before
![image](https://user-images.githubusercontent.com/2633655/113211679-cc1f4e80-9243-11eb-9072-04809a82446e.png)
![image](https://user-images.githubusercontent.com/2633655/113212624-04735c80-9245-11eb-9477-c855a9bfc98e.png)

After
![image](https://user-images.githubusercontent.com/2633655/113211709-d6d9e380-9243-11eb-9808-6f9f33a423cc.png)
![image](https://user-images.githubusercontent.com/2633655/113212633-0806e380-9245-11eb-8d71-86e2ea4838ca.png)
