### PR TITLE
Add referer to get request to google

### DIFF
--- a/tools/python/youtube_info_updater/youtube_info_updater.py
+++ b/tools/python/youtube_info_updater/youtube_info_updater.py
@@ -60,7 +60,8 @@ class YoutubeInfoUpdater():
         self.__logger.debug(f'get_video_info executing, args [{league}]')
 
         league_id = self.__leagues[league.lower()]
-        response = requests.get(f'{self.__google_api_url}&channelId={league_id}')
+        response = requests.get(f'{self.__google_api_url}&channelId={league_id}',
+            headers={"referer":"index.simulationhockey.com"})
         response_payload = response.json()
 
         if response.status_code == 403 and 'quota' in response_payload['error']['message']:


### PR DESCRIPTION
Add a referer to the python script.  

Fun fact, for some reason "referer" is actually misspelled, should be "referrer", but for some reason the HTTP people let it go.