### PR TITLE
Add position filters to leaders

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -14,10 +14,11 @@ interface Props {
   Sprites: {
     [index: string]: React.ComponentClass<any>;
   };
+  position?: string;
 }
 
-const Leaderboard = ({ league, playerType, stat, seasonType, Sprites }: Props): JSX.Element => {
-  const { leaders, isError, isLoading } = useLeaders(league, playerType, stat.id, seasonType);
+const Leaderboard = ({ league, playerType, stat, seasonType, Sprites, position }: Props): JSX.Element => {
+  const { leaders, isError, isLoading } = useLeaders(league, playerType, stat.id, seasonType, position);
 
   const convertStatValue = (value: string | number) => {
     if (typeof value === "string") return value;

--- a/components/Selector/LeadersFilterSelector.tsx
+++ b/components/Selector/LeadersFilterSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import {
   Container,
@@ -44,7 +44,7 @@ function LeadersFilterSelector({ activeFilter, onChange }: Props): JSX.Element {
 
   useEffect(() => setSelectedLeadersFilter(activeFilter), [activeFilter]);
 
-  const onButtonClick = () => setIsExpanded(!isExpanded);
+  const onButtonClick = useCallback(() => setIsExpanded((expanded) => !expanded), [setIsExpanded]);
   const onLeadersFilterSelect = (event) => {
     const { leadersfilter } = event.target.dataset;
     onChange(leadersfilter);

--- a/components/Selector/LeadersFilterSelector.tsx
+++ b/components/Selector/LeadersFilterSelector.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import {
+  Container,
+  ButtonContent,
+  DropdownButton,
+  DropdownItem,
+  DropdownList,
+  Caret,
+} from './styles';
+
+export type LeadersFilter = 'Skaters' | 'Forwards' | 'Defensemen' | 'Goalies';
+
+interface Props {
+  activeFilter: LeadersFilter;
+  onChange: (type: LeadersFilter) => void;
+}
+
+const FILTERS: {
+  [key: string]: LeadersFilter;
+} = {
+  SKATERS: 'Skaters',
+  FORWARDS: 'Forwards',
+  DEFENSEMEN: 'Defensemen',
+  GOALIES: 'Goalies'
+};
+
+function LeadersFilterSelector({ activeFilter, onChange }: Props): JSX.Element {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [selectedLeadersFilter, setSelectedLeadersFilter] = useState(activeFilter);
+  const selectorRef = useRef(null);
+  const onMouseLeave = () => {
+    setIsExpanded(false);
+    if (selectorRef.current) {
+      selectorRef.current.removeEventListener('mouseleave', onMouseLeave);
+    }
+  };
+
+  useEffect(() => {
+    if (isExpanded && selectorRef.current) {
+      selectorRef.current.addEventListener('mouseleave', onMouseLeave);
+    }
+  }, [selectorRef, isExpanded]);
+
+  useEffect(() => setSelectedLeadersFilter(activeFilter), [activeFilter]);
+
+  const onButtonClick = () => setIsExpanded(!isExpanded);
+  const onLeadersFilterSelect = (event) => {
+    const { leadersfilter } = event.target.dataset;
+    onChange(leadersfilter);
+    setSelectedLeadersFilter(leadersfilter);
+    setIsExpanded(false);
+  };
+
+  return (
+    <Container ref={selectorRef}>
+      <DropdownButton onClick={onButtonClick} inverse>
+        <ButtonContent>
+          {selectedLeadersFilter}
+          <FarCaret className={isExpanded ? 'up' : 'down'} inverse />
+        </ButtonContent>
+      </DropdownButton>
+      {isExpanded && (
+        <DropdownList>
+          {Object.keys(FILTERS).map((type) => (
+            <DropdownItem
+              key={FILTERS[type]}
+              align="left"
+              data-leadersfilter={FILTERS[type]}
+              onClick={onLeadersFilterSelect}
+              className={FILTERS[type] === selectedLeadersFilter && 'active'}
+            >
+              {FILTERS[type]}
+            </DropdownItem>
+          ))}
+        </DropdownList>
+      )}
+    </Container>
+  );
+}
+
+const FarCaret = styled(Caret)`
+  margin-left: auto;
+`;
+
+export default React.memo(LeadersFilterSelector);

--- a/hooks/useLeaders.ts
+++ b/hooks/useLeaders.ts
@@ -37,14 +37,15 @@ const useLeaders = (
       : '&type=regular';
   const seasonParam = season ? `&season=${season}` : '';
   const limitParam = limit ? `&limit=${limit}` : '';
+  const positionParam = position ? `&position=${position}` : '';
   const endpoint =
     playerType.toLowerCase() === 'goalie'
       ? `/goalies/${stat}`
-      : `/skaters/${stat}?position=${position}&`;
+      : `/skaters/${stat}`;
 
   const { data, error } = useSWR(
     () =>
-      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/leaders${endpoint}?league=${leagueid}${seasonParam}${limitParam}${seasonTypeParam}`
+      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/leaders${endpoint}?league=${leagueid}${seasonParam}${limitParam}${seasonTypeParam}${positionParam}`
   );
 
   return {

--- a/hooks/useLeaders.ts
+++ b/hooks/useLeaders.ts
@@ -7,6 +7,7 @@ const useLeaders = (
   playerType = 'skater',
   stat = 'goals',
   seasonType = 'Regular Season',
+  position = 'all',
   limit = 10
 ): {
   leaders: Array<{
@@ -39,7 +40,7 @@ const useLeaders = (
   const endpoint =
     playerType.toLowerCase() === 'goalie'
       ? `/goalies/${stat}`
-      : `/skaters/${stat}`;
+      : `/skaters/${stat}?position=${position}&`;
 
   const { data, error } = useSWR(
     () =>

--- a/pages/[league]/index.tsx
+++ b/pages/[league]/index.tsx
@@ -19,6 +19,7 @@ function LeagueHome({ league }: Props): JSX.Element {
     'skater',
     'goals',
     null,
+    'all',
     1
   );
   const { leaders: pointLeader, isLoading: isLoadingPL } = useLeaders(
@@ -26,6 +27,7 @@ function LeagueHome({ league }: Props): JSX.Element {
     'skater',
     'points',
     null,
+    'all',
     1
   );
   const { leaders: winLeader, isLoading: isLoadingWL } = useLeaders(
@@ -33,6 +35,7 @@ function LeagueHome({ league }: Props): JSX.Element {
     'goalie',
     'wins',
     null,
+    'all',
     1
   );
   const { leaders: shutoutLeader, isLoading: isLoadingSL } = useLeaders(
@@ -40,6 +43,7 @@ function LeagueHome({ league }: Props): JSX.Element {
     'goalie',
     'shutouts',
     null,
+    'all',
     1
   );
 

--- a/pages/[league]/leaders.tsx
+++ b/pages/[league]/leaders.tsx
@@ -6,20 +6,9 @@ import { NextSeo } from 'next-seo';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
 import SeasonTypeSelector from '../../components/Selector/SeasonTypeSelector';
+import LeadersFilterSelector, { LeadersFilter } from '../../components/Selector/LeadersFilterSelector';
 import { SeasonType } from '../api/v1/schedule';
 import Leaderboard from '../../components/Leaderboard';
-
-const PLAYER_TYPES = {
-  SKATER: 'skater',
-  GOALIE: 'goalie'
-};
-const SKATER_POSITIONS = {
-  ALL: 'all',
-  DEFENSE: 'd',
-  FORWARD: 'f'
-};
-type PlayerTypes = typeof PLAYER_TYPES[keyof typeof PLAYER_TYPES];
-type SkaterPositions = typeof SKATER_POSITIONS[keyof typeof SKATER_POSITIONS];
 
 const skaterLeaderboards = {
   goals: 'Goals',
@@ -52,8 +41,7 @@ interface Props {
 }
 
 function Stats({ league }: Props): JSX.Element {
-  const [playerType, setPlayerType] = useState<PlayerTypes>(PLAYER_TYPES.SKATER);
-  const [skaterPosition, setSkaterPosition] = useState<SkaterPositions>(SKATER_POSITIONS.ALL);
+  const [filter, setFilter] = useState<LeadersFilter>('Skaters');
   const [seasonType, setSeasonType] = useState<SeasonType>('Regular Season');
   const [isLoadingAssets, setLoadingAssets] = useState<boolean>(true);
   const [sprites, setSprites] = useState<{
@@ -73,11 +61,14 @@ function Stats({ league }: Props): JSX.Element {
   }, []);
 
   const onSeasonTypeSelect = (type) => setSeasonType(type);
+  const onLeadersFilterSelect = (filter) => setFilter(filter);
 
   if (isLoadingAssets || !sprites) return null;
 
   const renderLeaderboards = () => {
-    const leaderboards = playerType === PLAYER_TYPES.SKATER? skaterLeaderboards : goalieLeaderboards;
+    const leaderboards = filter === 'Goalies' ? goalieLeaderboards : skaterLeaderboards;
+    const playerType = filter === 'Goalies' ? 'goalie' : 'skater';
+    const skaterPosition = filter === 'Forwards' ? 'f' : filter === 'Defensemen' ? 'd' : '';
 
     return Object.entries(leaderboards).map(([statId, statLabel]) => (
       <Leaderboard
@@ -108,53 +99,44 @@ function Stats({ league }: Props): JSX.Element {
         <Filters>
           <SelectorWrapper>
             <SeasonTypeSelector onChange={onSeasonTypeSelect} />
+            <SmallScreenFilters>
+              <LeadersFilterSelector activeFilter={filter} onChange={onLeadersFilterSelect} />
+            </SmallScreenFilters>
           </SelectorWrapper>
           <DisplaySelectContainer role="tablist">
             <DisplaySelectItem
-              onClick={() => {
-                setPlayerType(() => PLAYER_TYPES.SKATER);
-                setSkaterPosition(() => SKATER_POSITIONS.ALL);
-              }}
-              active={playerType === PLAYER_TYPES.SKATER && skaterPosition === SKATER_POSITIONS.ALL}
+              onClick={() => setFilter('Skaters')}
+              active={filter === 'Skaters'}
               tabIndex={0}
               role="tab"
-              aria-selected={playerType === PLAYER_TYPES.SKATER}
+              aria-selected={filter === 'Skaters'}
             >
               Skaters
             </DisplaySelectItem>
             <DisplaySelectItem
-              onClick={() => {
-                setPlayerType(() => PLAYER_TYPES.SKATER);
-                setSkaterPosition(() => SKATER_POSITIONS.FORWARD);
-              }}
-              active={skaterPosition === SKATER_POSITIONS.FORWARD}
+              onClick={() => setFilter('Forwards')}
+              active={filter === 'Forwards'}
               tabIndex={0}
               role="tab"
-              aria-selected={skaterPosition === SKATER_POSITIONS.FORWARD}
+              aria-selected={filter === 'Forwards'}
             >
               Forwards
             </DisplaySelectItem>
             <DisplaySelectItem
-              onClick={() => {
-                setPlayerType(() => PLAYER_TYPES.SKATER);
-                setSkaterPosition(() => SKATER_POSITIONS.DEFENSE);
-              }}
-              active={skaterPosition === SKATER_POSITIONS.DEFENSE}
+              onClick={() => setFilter('Defensemen')}
+              active={filter === 'Defensemen'}
               tabIndex={0}
               role="tab"
-              aria-selected={skaterPosition === SKATER_POSITIONS.DEFENSE}
+              aria-selected={filter === 'Defensemen'}
             >
               Defensemen
             </DisplaySelectItem>
             <DisplaySelectItem
-              onClick={() => {
-                setPlayerType(() => PLAYER_TYPES.GOALIE);
-                setSkaterPosition(() => SKATER_POSITIONS.ALL);
-              }}
-              active={playerType === PLAYER_TYPES.GOALIE}
+              onClick={() => setFilter('Goalies')}
+              active={filter === 'Goalies'}
               tabIndex={0}
               role="tab"
-              aria-selected={playerType === PLAYER_TYPES.GOALIE}
+              aria-selected={filter === 'Goalies'}
             >
               Goalies
             </DisplaySelectItem>
@@ -205,6 +187,10 @@ const DisplaySelectContainer = styled.div`
   margin: 28px auto;
   width: 95%;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grey500};
+
+  @media screen and (max-width: 600px) {
+    display: none;
+  }
 `;
 
 const DisplaySelectItem = styled.div<{ active: boolean }>`
@@ -219,6 +205,14 @@ const DisplaySelectItem = styled.div<{ active: boolean }>`
   position: relative;
   border-bottom: none;
   bottom: -1px;
+`;
+
+const SmallScreenFilters = styled.div`
+  display: none;
+
+  @media screen and (max-width: 600px) {
+    display: block;
+  }
 `;
 
 const LeaderBoards = styled.div`

--- a/pages/[league]/leaders.tsx
+++ b/pages/[league]/leaders.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { NextSeo } from 'next-seo';
@@ -60,8 +60,8 @@ function Stats({ league }: Props): JSX.Element {
     })();
   }, []);
 
-  const onSeasonTypeSelect = (type) => setSeasonType(type);
-  const onLeadersFilterSelect = (filter) => setFilter(filter);
+  const onSeasonTypeSelect = useCallback((type) => setSeasonType(type), [setSeasonType]);
+  const onLeadersFilterSelect = useCallback((filter) => setFilter(filter), [setFilter]);
 
   if (isLoadingAssets || !sprites) return null;
 

--- a/pages/[league]/leaders.tsx
+++ b/pages/[league]/leaders.tsx
@@ -158,14 +158,14 @@ const Container = styled.div`
   margin: 0 auto;
   background-color: ${({ theme }) => theme.colors.grey100};
 
-  @media screen and (max-width: 1024px) {
+  @media screen and (max-width: 1050px) {
     width: 100%;
     padding: 2.5%;
   }
 `;
 
 const Filters = styled.div`
-  @media screen and (max-width: 1024px) {
+  @media screen and (max-width: 1050px) {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -188,7 +188,7 @@ const DisplaySelectContainer = styled.div`
   width: 95%;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grey500};
 
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: 1050px) {
     display: none;
   }
 `;
@@ -210,7 +210,7 @@ const DisplaySelectItem = styled.div<{ active: boolean }>`
 const SmallScreenFilters = styled.div`
   display: none;
 
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: 1050px) {
     display: block;
   }
 `;

--- a/pages/[league]/leaders.tsx
+++ b/pages/[league]/leaders.tsx
@@ -13,7 +13,13 @@ const PLAYER_TYPES = {
   SKATER: 'skater',
   GOALIE: 'goalie'
 };
+const SKATER_POSITIONS = {
+  ALL: 'all',
+  DEFENSE: 'd',
+  FORWARD: 'f'
+};
 type PlayerTypes = typeof PLAYER_TYPES[keyof typeof PLAYER_TYPES];
+type SkaterPositions = typeof SKATER_POSITIONS[keyof typeof SKATER_POSITIONS];
 
 const skaterLeaderboards = {
   goals: 'Goals',
@@ -47,6 +53,7 @@ interface Props {
 
 function Stats({ league }: Props): JSX.Element {
   const [playerType, setPlayerType] = useState<PlayerTypes>(PLAYER_TYPES.SKATER);
+  const [skaterPosition, setSkaterPosition] = useState<SkaterPositions>(SKATER_POSITIONS.ALL);
   const [seasonType, setSeasonType] = useState<SeasonType>('Regular Season');
   const [isLoadingAssets, setLoadingAssets] = useState<boolean>(true);
   const [sprites, setSprites] = useState<{
@@ -70,7 +77,7 @@ function Stats({ league }: Props): JSX.Element {
   if (isLoadingAssets || !sprites) return null;
 
   const renderLeaderboards = () => {
-    const leaderboards = playerType === PLAYER_TYPES.SKATER ? skaterLeaderboards : goalieLeaderboards;
+    const leaderboards = playerType === PLAYER_TYPES.SKATER? skaterLeaderboards : goalieLeaderboards;
 
     return Object.entries(leaderboards).map(([statId, statLabel]) => (
       <Leaderboard
@@ -83,6 +90,7 @@ function Stats({ league }: Props): JSX.Element {
         }}
         seasonType={seasonType}
         Sprites={sprites}
+        position={skaterPosition}
       />
     ))
   };
@@ -103,8 +111,11 @@ function Stats({ league }: Props): JSX.Element {
           </SelectorWrapper>
           <DisplaySelectContainer role="tablist">
             <DisplaySelectItem
-              onClick={() => setPlayerType(() => PLAYER_TYPES.SKATER)}
-              active={playerType === PLAYER_TYPES.SKATER}
+              onClick={() => {
+                setPlayerType(() => PLAYER_TYPES.SKATER);
+                setSkaterPosition(() => SKATER_POSITIONS.ALL);
+              }}
+              active={playerType === PLAYER_TYPES.SKATER && skaterPosition === SKATER_POSITIONS.ALL}
               tabIndex={0}
               role="tab"
               aria-selected={playerType === PLAYER_TYPES.SKATER}
@@ -112,7 +123,34 @@ function Stats({ league }: Props): JSX.Element {
               Skaters
             </DisplaySelectItem>
             <DisplaySelectItem
-              onClick={() => setPlayerType(() => PLAYER_TYPES.GOALIE)}
+              onClick={() => {
+                setPlayerType(() => PLAYER_TYPES.SKATER);
+                setSkaterPosition(() => SKATER_POSITIONS.FORWARD);
+              }}
+              active={skaterPosition === SKATER_POSITIONS.FORWARD}
+              tabIndex={0}
+              role="tab"
+              aria-selected={skaterPosition === SKATER_POSITIONS.FORWARD}
+            >
+              Forwards
+            </DisplaySelectItem>
+            <DisplaySelectItem
+              onClick={() => {
+                setPlayerType(() => PLAYER_TYPES.SKATER);
+                setSkaterPosition(() => SKATER_POSITIONS.DEFENSE);
+              }}
+              active={skaterPosition === SKATER_POSITIONS.DEFENSE}
+              tabIndex={0}
+              role="tab"
+              aria-selected={skaterPosition === SKATER_POSITIONS.DEFENSE}
+            >
+              Defensemen
+            </DisplaySelectItem>
+            <DisplaySelectItem
+              onClick={() => {
+                setPlayerType(() => PLAYER_TYPES.GOALIE);
+                setSkaterPosition(() => SKATER_POSITIONS.ALL);
+              }}
               active={playerType === PLAYER_TYPES.GOALIE}
               tabIndex={0}
               role="tab"

--- a/pages/api/v1/leaders/skaters/assists.ts
+++ b/pages/api/v1/leaders/skaters/assists.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY Assists `

--- a/pages/api/v1/leaders/skaters/goals.ts
+++ b/pages/api/v1/leaders/skaters/goals.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY Goals `

--- a/pages/api/v1/leaders/skaters/penaltyminutes.ts
+++ b/pages/api/v1/leaders/skaters/penaltyminutes.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY PenaltyMinutes `

--- a/pages/api/v1/leaders/skaters/plusminus.ts
+++ b/pages/api/v1/leaders/skaters/plusminus.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY plusMinus `

--- a/pages/api/v1/leaders/skaters/points.ts
+++ b/pages/api/v1/leaders/skaters/points.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY Points `

--- a/pages/api/v1/leaders/skaters/ppg.ts
+++ b/pages/api/v1/leaders/skaters/ppg.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY PowerPlayGoals `

--- a/pages/api/v1/leaders/skaters/shg.ts
+++ b/pages/api/v1/leaders/skaters/shg.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY ShorthandedGoals `

--- a/pages/api/v1/leaders/skaters/shotpct.ts
+++ b/pages/api/v1/leaders/skaters/shotpct.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY ShotPct `

--- a/pages/api/v1/leaders/skaters/shots.ts
+++ b/pages/api/v1/leaders/skaters/shots.ts
@@ -19,6 +19,7 @@ export default async (
     season: seasonid,
     type: longType = 'regular',
     limit = 10,
+    position = 'all',
     desc = true,
   } = req.query;
 
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY Shots `

--- a/pages/api/v1/leaders/skaters/shotsblocked.ts
+++ b/pages/api/v1/leaders/skaters/shotsblocked.ts
@@ -18,6 +18,7 @@ export default async (
     league = 0,
     season: seasonid,
     type: longType = 'regular',
+    position = 'all',
     limit = 10,
     desc = true,
   } = req.query;
@@ -59,6 +60,15 @@ export default async (
       ON s.TeamID = t.TeamID
       AND s.SeasonID = t.SeasonID
       AND s.LeagueID = t.LeagueID
+    INNER JOIN corrected_player_ratings as r
+      ON s.SeasonID = r.SeasonID 
+      AND s.LeagueID = r.LeagueID
+      AND s.PlayerID = r.PlayerID `
+      ).append(
+        position === 'd' ? 'AND ( r.LD = 20 OR r.RD = 20 )' :
+        position === 'f' ? 'AND NOT ( r.LD = 20 OR r.RD = 20 )' : ''
+      ).append(
+        SQL`
     WHERE s.LeagueID=${+league}
     AND s.SeasonID=${season.SeasonID}
     ORDER BY ShotsBlocked `


### PR DESCRIPTION
This adds two new filters to the Leaders page: Forwards & Defensemen

**Desktop**
![image](https://user-images.githubusercontent.com/2633655/124035872-278be480-d9cb-11eb-97d6-a59f08aafdbd.png)

**Mobile**
![image](https://user-images.githubusercontent.com/2633655/124035909-35416a00-d9cb-11eb-85cb-c9153ebf35fe.png)
