### PR TITLE
Make sure hook always renders

### DIFF
--- a/components/ScoreTable/index.tsx
+++ b/components/ScoreTable/index.tsx
@@ -135,6 +135,8 @@ Props): JSX.Element {
     updateFilter(event.target.value, null);
   }, [setSearchText, updateFilter]);
 
+  const goToLastPage = useCallback(() => gotoPage(pageCount - 1), [pageCount]);
+
   return (
     <>
       {!hasData && <Notice>No results found</Notice>}
@@ -259,7 +261,7 @@ Props): JSX.Element {
           </button>{' '}
           <button
             className="-next"
-            onClick={useCallback(() => gotoPage(pageCount - 1), [pageCount])}
+            onClick={goToLastPage}
             disabled={!canNextPage}
           >
             {'>>'}


### PR DESCRIPTION
There's a race condition where this `useCallback` hook might not be rendered depending on how quickly we get the player data.
Causing this to show to the users when navigating to the /players page:
![image](https://user-images.githubusercontent.com/2633655/125358962-9d7f3c80-e337-11eb-8272-d01574798f15.png)

React error says "Rendered more hooks than during the previous render."

I'm able to reproduce this bug every time in a new incognito browser window. Reloading once solves it.
