### PR TITLE
Only use finals label for the cup finals

### DIFF
--- a/components/PlayoffsBracket/DoubleBracket.tsx
+++ b/components/PlayoffsBracket/DoubleBracket.tsx
@@ -172,7 +172,7 @@ function DoubleBracket({ data, league }: Props): JSX.Element {
 
   const renderRound = (round, conference, index) => (
     <Round key={index} conference={conference}>
-      <h2>{round.length === 1 ? 'Finals' : `Round ${index + 1}`}</h2>
+      <h2>{round.length === 1 && conference === CONFERENCE.MIXED ? 'Finals' : `Round ${index + 1}`}</h2>
       {round.map((series) => renderSeries(series))}
     </Round>
   );


### PR DESCRIPTION
Currently the 3rd round of the SHL playoffs are labels as "Finals" instead of "Round 3". This makes sure "Finals" is reserved for the cup finals round only.