### PR TITLE
Don't crash when missing playoffs data

### DIFF
--- a/components/PlayoffsBracket/SingleBracket.tsx
+++ b/components/PlayoffsBracket/SingleBracket.tsx
@@ -144,6 +144,14 @@ function SingleBracket({ data, league }: Props): JSX.Element {
 
   const renderBracket = () => data.map((round, i) => renderRound(round, i));
 
+  if (data.length === 0) {
+    return (
+      <Container>
+        <Notice>Playoffs bracket is not yet available</Notice>
+      </Container>
+    );
+  }
+
   return (
     <Container>
       <Bracket>{renderBracket()}</Bracket>
@@ -238,6 +246,14 @@ export const SeriesScore = styled.div`
   font-size: 25px;
   text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
   margin-left: auto;
+`;
+
+const Notice = styled.div`
+  width: 100%;
+  font-size: 20px;
+  font-weight: 700;
+  text-align: center;
+  padding: 5px;
 `;
 
 export default React.memo(SingleBracket);

--- a/pages/[league]/standings.tsx
+++ b/pages/[league]/standings.tsx
@@ -34,7 +34,7 @@ function Standings({ league }: Props): JSX.Element {
   const renderDoublePlayoffsBracket = useCallback(() =>
     // The double bracket needs enough space to properly render
     // We use the single bracket when the window is too small or if we have too few series in the first round
-    data && (data[0] as PlayoffsRound).length > 4 && windowSize.width > 1370
+    data && data[0] && (data[0] as PlayoffsRound).length > 4 && windowSize.width > 1370
   , [windowSize, data]);
 
   return (


### PR DESCRIPTION
If the simmer doesn't sim far enough ahead to have FHM generate the first playoffs matchups the playoffs API endpoint will return an empty array. This breaks the `/standings` page when the user selects to see the playoffs view.

This PR adds a length check and a message in case we don't have any playoffs data.

![image](https://user-images.githubusercontent.com/2633655/129796126-51aa9c6c-6687-49ca-a735-a066462b34db.png)
