### PR TITLE
Set and Get seasonType from Query Params

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -8,7 +8,6 @@ interface Props {
   league: string;
   playerType: string;
   stat: string;
-  seasonType: string;
   Sprites: {
     [index: string]: React.ComponentClass<any>;
   };
@@ -19,7 +18,6 @@ const Leaderboard = ({
   league,
   playerType,
   stat,
-  seasonType,
   Sprites,
   position,
 }: Props): JSX.Element => {
@@ -27,7 +25,6 @@ const Leaderboard = ({
     league,
     playerType,
     stat,
-    seasonType,
     position
   );
 

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -56,8 +56,8 @@ const Leaderboard = ({
     return (isDesc ? current / leader : leader / current) * 100;
   };
 
-  if (!leaders || isError || isLoading) {
-    return <SkeletonLeaderboard isError={isError} />;
+  if (!leaders || isError || isLoading || !leaders.length) {
+    return <SkeletonLeaderboard isError={isError} leaders={leaders} />;
   }
 
   const renderLeaders = () => {
@@ -111,8 +111,10 @@ const Leaderboard = ({
 
 const SkeletonLeaderboard = ({
   isError,
+  leaders,
 }: {
   isError: boolean;
+  leaders: any;
 }): JSX.Element => (
   <SkeletonTheme color="#ADB5BD" highlightColor="#CED4DA">
     {isError && (
@@ -122,7 +124,13 @@ const SkeletonLeaderboard = ({
         </strong>
       </Container>
     )}
-    {!isError && (
+    {!isError && leaders && (
+      <Container>
+        <strong>No data available</strong>
+      </Container>
+    )}
+
+    {!isError && !leaders && (
       <Container>
         <Skeleton width={150} height={30} />
         <TopTen>

--- a/components/LinkWithSeason.tsx
+++ b/components/LinkWithSeason.tsx
@@ -2,6 +2,7 @@ import Link, { LinkProps } from 'next/link';
 import React from 'react';
 
 import { getQuerySeason } from '../utils/season';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 interface SeasonLinkProps extends LinkProps {
   disabled?: boolean;
@@ -18,10 +19,17 @@ function LinkWithSeason({
   }
 
   const querySeason = getQuerySeason();
+  const querySeasonType = getQuerySeasonType();
   const seasonParam = querySeason ? `?season=${querySeason}` : '';
+  const seasonTypeParam =
+    seasonParam && querySeasonType
+      ? `&type=${querySeasonType}`
+      : querySeasonType
+      ? `?type=${querySeasonType}`
+      : '';
   const updatedProps = {
     ...props,
-    as: `${as}${seasonParam}`,
+    as: `${as}${seasonParam}${seasonTypeParam}`,
   };
 
   return <Link {...updatedProps}>{children}</Link>;

--- a/components/STHS/Leaderboard.tsx
+++ b/components/STHS/Leaderboard.tsx
@@ -9,22 +9,10 @@ interface Props {
   league: string;
   playerType: string;
   stat: string;
-  seasonType: string;
 }
 
-const Leaderboard = ({
-  league,
-  playerType,
-  stat,
-  seasonType,
-}: Props): JSX.Element => {
-  const { leaders, isLoading } = useLeaders(
-    league,
-    playerType,
-    stat,
-    seasonType,
-    null
-  );
+const Leaderboard = ({ league, playerType, stat }: Props): JSX.Element => {
+  const { leaders, isLoading } = useLeaders(league, playerType, stat, null);
 
   const columnData = [
     {

--- a/components/Selector/SeasonSelector.tsx
+++ b/components/Selector/SeasonSelector.tsx
@@ -53,6 +53,7 @@ function SeasonSelector({ seasons, loading }: Props): JSX.Element {
   const onSeasonSelect = (event) => {
     const season = event.target.dataset.season;
     const seasonInSearch = window.location.search.match(/([?|&])season=\d+/);
+    const queryParamsExist = window.location.search.match(/[?|&]/);
 
     if (season && season.match(/\d+/)) {
       const updatedSearch = seasonInSearch
@@ -60,6 +61,8 @@ function SeasonSelector({ seasons, loading }: Props): JSX.Element {
             seasonInSearch[0],
             `${seasonInSearch[1]}season=${season}`
           )
+        : queryParamsExist
+        ? `${window.location.search}&season=${season}`
         : `?season=${season}`;
       const newPath = `${window.location.pathname}${updatedSearch}`;
       router.push(newPath);

--- a/components/Selector/SeasonTypeSelector.tsx
+++ b/components/Selector/SeasonTypeSelector.tsx
@@ -14,7 +14,7 @@ import {
 } from './styles';
 
 interface Props {
-  onChange?: (type: SeasonType) => void;
+  onChange: (type: SeasonType) => void;
 }
 
 export const SEASON_TYPE: {
@@ -77,7 +77,9 @@ function SeasonTypeSelector({ onChange }: Props): JSX.Element {
         : `?type=${parsedSeasonType.toLowerCase()}`;
       window.history.pushState(null, null, updatedSearch);
       setSelectedSeasonType(seasontype);
-      onChange(seasontype as SeasonType);
+      if (onChange) {
+        onChange(seasontype);
+      }
       setIsExpanded(false);
     }
   };

--- a/components/Selector/SeasonTypeSelector.tsx
+++ b/components/Selector/SeasonTypeSelector.tsx
@@ -14,10 +14,10 @@ import {
 } from './styles';
 
 interface Props {
-  onChange: (type: SeasonType) => void;
+  onChange?: (type: SeasonType) => void;
 }
 
-const SEASON_TYPE: {
+export const SEASON_TYPE: {
   [key: string]: SeasonType;
 } = {
   PRE: 'Pre-Season',

--- a/components/Selector/SeasonTypeSelector.tsx
+++ b/components/Selector/SeasonTypeSelector.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { SeasonType } from '../../pages/api/v1/schedule';
+import { getQuerySeasonType } from '../../utils/seasonType';
 
 import {
   Container,
@@ -44,12 +45,41 @@ function SeasonTypeSelector({ onChange }: Props): JSX.Element {
     }
   }, [selectorRef, isExpanded]);
 
+  useEffect(() => {
+    let nextSeasonType = getQuerySeasonType();
+
+    if (!nextSeasonType) {
+      nextSeasonType = SEASON_TYPE.REGULAR;
+    }
+
+    setSelectedSeasonType(SEASON_TYPE[nextSeasonType.toUpperCase()]);
+  }, []);
+
   const onButtonClick = () => setIsExpanded(!isExpanded);
   const onSeasonTypeSelect = (event) => {
     const { seasontype } = event.target.dataset;
-    onChange(seasontype);
-    setSelectedSeasonType(seasontype);
-    setIsExpanded(false);
+    const seasonTypeInSearch = window.location.search.match(/([?|&])type=\w+/);
+    const queryParamsExist = window.location.search.match(/[?|&]/);
+
+    if (seasontype && seasontype.match(/\w+/)) {
+      // set seasontype to key of seasonType in SEASON_TYPE
+      const parsedSeasonType = Object.keys(SEASON_TYPE).find(
+        (key) => SEASON_TYPE[key] === seasontype
+      );
+
+      const updatedSearch = seasonTypeInSearch
+        ? window.location.search.replace(
+            seasonTypeInSearch[0],
+            `${seasonTypeInSearch[1]}type=${parsedSeasonType.toLowerCase()}`
+          )
+        : queryParamsExist
+        ? `${window.location.search}&type=${parsedSeasonType.toLowerCase()}`
+        : `?type=${parsedSeasonType.toLowerCase()}`;
+      window.history.pushState(null, null, updatedSearch);
+      setSelectedSeasonType(seasontype);
+      onChange(seasontype as SeasonType);
+      setIsExpanded(false);
+    }
   };
 
   return (

--- a/components/StandingsTable.tsx
+++ b/components/StandingsTable.tsx
@@ -313,7 +313,7 @@ function StandingsTable({
               ),
           }))
         : columnData,
-    [isLoading, isLoadingAssets, title]
+    [isLoading, isLoadingAssets, title, standings]
   );
 
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =

--- a/hooks/useGoalieStats.ts
+++ b/hooks/useGoalieStats.ts
@@ -1,11 +1,12 @@
 import useSWR from 'swr';
 
 import { Goalie } from '..';
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
 import { getQuerySeason } from '../utils/season';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 const useGoalieStats = (
-  league: string,
-  seasonType: string
+  league: string
 ): {
   ratings: Array<Goalie>;
   isLoading: boolean;
@@ -13,6 +14,7 @@ const useGoalieStats = (
 } => {
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
   const season = getQuerySeason();
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
   const seasonParam = season ? `&season=${season}` : '';
   const seasonTypeParam = seasonType
     ? `&type=${seasonType.toLowerCase().replace('-', '')}`

--- a/hooks/useGoalieStatsId.ts
+++ b/hooks/useGoalieStatsId.ts
@@ -1,17 +1,19 @@
 import useSWR from 'swr';
 
 import { Goalie } from '..';
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 const useGoalieStatsId = (
   id: number,
-  league: string,
-  seasonType: string
+  league: string
 ): {
   ratings: Array<Goalie>;
   isLoading: boolean;
   isError: boolean;
 } => {
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
   const seasonTypeParam = seasonType
     ? `&type=${seasonType.toLowerCase().replace('-', '')}`
     : '';

--- a/hooks/useLeaders.ts
+++ b/hooks/useLeaders.ts
@@ -1,12 +1,13 @@
 import useSWR from 'swr';
 
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
 import { getQuerySeason } from '../utils/season';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 const useLeaders = (
   league: string,
   playerType = 'skater',
   stat = 'goals',
-  seasonType = 'Regular Season',
   position = 'all',
   limit = 10
 ): {
@@ -31,6 +32,7 @@ const useLeaders = (
 } => {
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
   const season = getQuerySeason();
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
   const seasonTypeParam =
     seasonType === 'Playoffs'
       ? '&type=playoffs'

--- a/hooks/useSchedule.ts
+++ b/hooks/useSchedule.ts
@@ -1,11 +1,12 @@
 import useSWR from 'swr';
 
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
 import { Game } from '../pages/api/v1/schedule';
 import { getQuerySeason } from '../utils/season';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 const useSchedule = (
-  league: string,
-  seasonType = 'Regular Season'
+  league: string
 ): {
   games: Array<Game>;
   isLoading: boolean;
@@ -14,6 +15,7 @@ const useSchedule = (
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
   const season = getQuerySeason();
   const seasonParam = season ? `&season=${season}` : '';
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
 
   const { data, error } = useSWR(
     () =>

--- a/hooks/useSkaterStats.ts
+++ b/hooks/useSkaterStats.ts
@@ -1,11 +1,12 @@
 import useSWR from 'swr';
 
 import { Player } from '..';
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
 import { getQuerySeason } from '../utils/season';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 const useSkaterStats = (
-  league: string,
-  seasonType: string
+  league: string
 ): {
   ratings: Array<Player>;
   isLoading: boolean;
@@ -13,6 +14,7 @@ const useSkaterStats = (
 } => {
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
   const season = getQuerySeason();
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
   const seasonParam = season ? `&season=${season}` : '';
   const seasonTypeParam = seasonType
     ? `&type=${seasonType.toLowerCase().replace('-', '')}`

--- a/hooks/useSkaterStatsId.ts
+++ b/hooks/useSkaterStatsId.ts
@@ -1,17 +1,19 @@
 import useSWR from 'swr';
 
 import { Player } from '..';
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 const useSkaterStatsId = (
   id: number,
-  league: string,
-  seasonType: string
+  league: string
 ): {
   ratings: Array<Player>;
   isLoading: boolean;
   isError: boolean;
 } => {
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
   const seasonTypeParam = seasonType
     ? `&type=${seasonType.toLowerCase().replace('-', '')}`
     : '';

--- a/hooks/useStandings.ts
+++ b/hooks/useStandings.ts
@@ -1,8 +1,10 @@
 import useSWR from 'swr';
 
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
 import { Standings } from '../pages/api/v1/standings';
 import { PlayoffsRound } from '../pages/api/v1/standings/playoffs';
 import { getQuerySeason } from '../utils/season';
+import { getQuerySeasonType } from '../utils/seasonType';
 
 interface Hook {
   data: Standings | Array<PlayoffsRound>;
@@ -10,12 +12,9 @@ interface Hook {
   isError: boolean;
 }
 
-const useStandings = (
-  league: string,
-  display = 'league',
-  seasonType = 'Regular Season'
-): Hook => {
+const useStandings = (league: string, display = 'league'): Hook => {
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
   const endpoint =
     seasonType === 'Playoffs'
       ? 'standings/playoffs'

--- a/hooks/useTeamRosterStats.ts
+++ b/hooks/useTeamRosterStats.ts
@@ -1,12 +1,13 @@
 import useSWR from 'swr';
 
 import { Player, Goalie } from '../';
+import { SEASON_TYPE } from '../components/Selector/SeasonTypeSelector';
 import { getQuerySeason } from '../utils/season';
+import { getQuerySeasonType } from '../utils/seasonType';
 
-const useStandings = (
+const useTeamRosterStats = (
   league: string,
-  team: number,
-  seasonType: string
+  team: number
 ): {
   roster: Array<Player | Goalie>;
   isLoading: boolean;
@@ -14,6 +15,7 @@ const useStandings = (
 } => {
   const leagueid = ['shl', 'smjhl', 'iihf', 'wjc'].indexOf(league);
   const season = getQuerySeason();
+  const seasonType = SEASON_TYPE[getQuerySeasonType().toUpperCase()];
   const seasonParam = season ? `&season=${season}` : '';
   const seasonTypeParam = seasonType
     ? `&type=${seasonType.toLowerCase().replace('-', '')}`
@@ -31,4 +33,4 @@ const useStandings = (
   };
 };
 
-export default useStandings;
+export default useTeamRosterStats;

--- a/pages/[league]/index.tsx
+++ b/pages/[league]/index.tsx
@@ -18,7 +18,6 @@ function LeagueHome({ league }: Props): JSX.Element {
     league,
     'skater',
     'goals',
-    null,
     'all',
     1
   );
@@ -26,7 +25,6 @@ function LeagueHome({ league }: Props): JSX.Element {
     league,
     'skater',
     'points',
-    null,
     'all',
     1
   );
@@ -34,7 +32,6 @@ function LeagueHome({ league }: Props): JSX.Element {
     league,
     'goalie',
     'wins',
-    null,
     'all',
     1
   );
@@ -42,7 +39,6 @@ function LeagueHome({ league }: Props): JSX.Element {
     league,
     'goalie',
     'shutouts',
-    null,
     'all',
     1
   );

--- a/pages/[league]/leaders.tsx
+++ b/pages/[league]/leaders.tsx
@@ -44,11 +44,17 @@ interface Props {
 }
 
 function Stats({ league }: Props): JSX.Element {
+  const [, setSeasonType] = useState('regular');
   const [filter, setFilter] = useState<LeadersFilter>('Skaters');
   const [isLoadingAssets, setLoadingAssets] = useState<boolean>(true);
   const [sprites, setSprites] = useState<{
     [index: string]: React.ComponentClass<any>;
   }>({});
+
+  const onSeasonTypeSelect = useCallback(
+    (seasonType) => setSeasonType(seasonType),
+    [setSeasonType]
+  );
 
   useEffect(() => {
     // Dynamically import svg icons based on the league chosen
@@ -100,7 +106,7 @@ function Stats({ league }: Props): JSX.Element {
       <Container>
         <Filters>
           <SelectorWrapper>
-            <SeasonTypeSelector />
+            <SeasonTypeSelector onChange={onSeasonTypeSelect} />
             <SmallScreenFilters>
               <LeadersFilterSelector
                 activeFilter={filter}

--- a/pages/[league]/leaders.tsx
+++ b/pages/[league]/leaders.tsx
@@ -10,7 +10,6 @@ import LeadersFilterSelector, {
   LeadersFilter,
 } from '../../components/Selector/LeadersFilterSelector';
 import SeasonTypeSelector from '../../components/Selector/SeasonTypeSelector';
-import { SeasonType } from '../api/v1/schedule';
 
 const skaterLeaderboards = [
   'goals',
@@ -46,7 +45,6 @@ interface Props {
 
 function Stats({ league }: Props): JSX.Element {
   const [filter, setFilter] = useState<LeadersFilter>('Skaters');
-  const [seasonType, setSeasonType] = useState<SeasonType>('Regular Season');
   const [isLoadingAssets, setLoadingAssets] = useState<boolean>(true);
   const [sprites, setSprites] = useState<{
     [index: string]: React.ComponentClass<any>;
@@ -64,10 +62,6 @@ function Stats({ league }: Props): JSX.Element {
     })();
   }, []);
 
-  const onSeasonTypeSelect = useCallback(
-    (type) => setSeasonType(type),
-    [setSeasonType]
-  );
   const onLeadersFilterSelect = useCallback(
     (filter) => setFilter(filter),
     [setFilter]
@@ -88,7 +82,6 @@ function Stats({ league }: Props): JSX.Element {
         league={league}
         playerType={playerType}
         stat={statId}
-        seasonType={seasonType}
         Sprites={sprites}
         position={skaterPosition}
       />
@@ -107,7 +100,7 @@ function Stats({ league }: Props): JSX.Element {
       <Container>
         <Filters>
           <SelectorWrapper>
-            <SeasonTypeSelector onChange={onSeasonTypeSelect} />
+            <SeasonTypeSelector />
             <SmallScreenFilters>
               <LeadersFilterSelector
                 activeFilter={filter}

--- a/pages/[league]/player/[id].tsx
+++ b/pages/[league]/player/[id].tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
 import Error from 'next/error';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { PulseLoader } from 'react-spinners';
 import styled from 'styled-components';
@@ -31,6 +31,7 @@ function PlayerPage({ league, teamList, id }: Props): JSX.Element {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isSkater, setIsSkater] = useState<boolean>(true);
   const [playerError, setPlayerError] = useState<boolean>(false);
+  const [, setSeasonType] = useState('regular');
 
   // player info
   const [playerName, setPlayerName] = useState('');
@@ -80,6 +81,13 @@ function PlayerPage({ league, teamList, id }: Props): JSX.Element {
     isLoading: isLoadingSkaterInfo,
     isError: isErrorSkaterInfo,
   } = useSkaterInfo(id, league);
+
+  const handleSeasonTypeChange = useCallback(
+    (seasonType: string) => {
+      setSeasonType(seasonType);
+    },
+    [setSeasonType]
+  );
 
   // wait for all loads to complete
   useEffect(() => {
@@ -185,7 +193,7 @@ function PlayerPage({ league, teamList, id }: Props): JSX.Element {
           )}
           <ControlWrapper>
             <SelectorWrapper>
-              <SeasonTypeSelector />
+              <SeasonTypeSelector onChange={handleSeasonTypeChange} />
             </SelectorWrapper>
           </ControlWrapper>
           {!isLoading && (

--- a/pages/[league]/player/[id].tsx
+++ b/pages/[league]/player/[id].tsx
@@ -21,7 +21,6 @@ import useGoalieStatsId from '../../../hooks/useGoalieStatsId';
 import useRatingsId from '../../../hooks/useRatingsId';
 import useSkaterInfo from '../../../hooks/useSkaterInfo';
 import useSkaterStatsId from '../../../hooks/useSkaterStatsId';
-import { SeasonType } from '../../api/v1/players/stats';
 
 interface Props {
   league: string;
@@ -32,7 +31,6 @@ function PlayerPage({ league, teamList, id }: Props): JSX.Element {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isSkater, setIsSkater] = useState<boolean>(true);
   const [playerError, setPlayerError] = useState<boolean>(false);
-  const [filterSeasonType, setFilterSeasonType] = useState('Regular Season');
 
   // player info
   const [playerName, setPlayerName] = useState('');
@@ -62,13 +60,13 @@ function PlayerPage({ league, teamList, id }: Props): JSX.Element {
     ratings: goalieStats,
     isLoading: isLoadingGoalieStats,
     isError: isErrorGoalieStats,
-  } = useGoalieStatsId(id, league, filterSeasonType);
+  } = useGoalieStatsId(id, league);
 
   const {
     ratings: skaterStats,
     isLoading: isLoadingSkaterStats,
     isError: isErrorSkaterStats,
-  } = useSkaterStatsId(id, league, filterSeasonType);
+  } = useSkaterStatsId(id, league);
 
   // player info
   const {
@@ -153,10 +151,6 @@ function PlayerPage({ league, teamList, id }: Props): JSX.Element {
     playerTeam,
   ]);
 
-  const onSeasonTypeSelect = async (seasonType: SeasonType) => {
-    setFilterSeasonType(seasonType);
-  };
-
   const [display, setDisplay] = useState('stats');
 
   if (
@@ -191,7 +185,7 @@ function PlayerPage({ league, teamList, id }: Props): JSX.Element {
           )}
           <ControlWrapper>
             <SelectorWrapper>
-              <SeasonTypeSelector onChange={onSeasonTypeSelect} />
+              <SeasonTypeSelector />
             </SelectorWrapper>
           </ControlWrapper>
           {!isLoading && (

--- a/pages/[league]/players.tsx
+++ b/pages/[league]/players.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { NextSeo } from 'next-seo';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 // import useSWR from 'swr';
@@ -25,6 +25,7 @@ interface Props {
 }
 
 function PlayerPage({ league }: Props): JSX.Element {
+  const [, setSeasonType] = useState('regular');
   const { ratings: skaterratings, isLoading: isLoadingPlayers } =
     useRatings(league);
   const { ratings: skater, isLoading: isLoadingPlayerStat } =
@@ -60,6 +61,11 @@ function PlayerPage({ league }: Props): JSX.Element {
 
   const [display, setDisplay] = useState('stats');
 
+  const onSeasonTypeSelect = useCallback(
+    (seasonType) => setSeasonType(seasonType),
+    [setSeasonType]
+  );
+
   return (
     <React.Fragment>
       <NextSeo
@@ -72,7 +78,7 @@ function PlayerPage({ league }: Props): JSX.Element {
       <Container>
         <Filters>
           <SelectorWrapper>
-            <SeasonTypeSelector />
+            <SeasonTypeSelector onChange={onSeasonTypeSelect} />
           </SelectorWrapper>
           <DisplaySelectContainer role="tablist">
             <DisplaySelectItem

--- a/pages/[league]/players.tsx
+++ b/pages/[league]/players.tsx
@@ -18,7 +18,6 @@ import useGoalieRatings from '../../hooks/useGoalieRatings';
 import useGoalieStats from '../../hooks/useGoalieStats';
 import useRatings from '../../hooks/useRatings';
 import useSkaterStats from '../../hooks/useSkaterStats';
-import { SeasonType } from '../api/v1/players/stats';
 
 interface Props {
   league: string;
@@ -28,12 +27,9 @@ interface Props {
 function PlayerPage({ league }: Props): JSX.Element {
   const { ratings: skaterratings, isLoading: isLoadingPlayers } =
     useRatings(league);
-  const [filterSeasonType, setFilterSeasonType] = useState('Regular Season');
-  const { ratings: skater, isLoading: isLoadingPlayerStat } = useSkaterStats(
-    league,
-    filterSeasonType
-  );
-  const { ratings: goalie } = useGoalieStats(league, filterSeasonType);
+  const { ratings: skater, isLoading: isLoadingPlayerStat } =
+    useSkaterStats(league);
+  const { ratings: goalie } = useGoalieStats(league);
 
   const { ratings: goalieratingdata, isLoading: isLoadingGoalies } =
     useGoalieRatings(league);
@@ -64,10 +60,6 @@ function PlayerPage({ league }: Props): JSX.Element {
 
   const [display, setDisplay] = useState('stats');
 
-  const onSeasonTypeSelect = async (seasonType: SeasonType) => {
-    setFilterSeasonType(seasonType);
-  };
-
   return (
     <React.Fragment>
       <NextSeo
@@ -80,7 +72,7 @@ function PlayerPage({ league }: Props): JSX.Element {
       <Container>
         <Filters>
           <SelectorWrapper>
-            <SeasonTypeSelector onChange={onSeasonTypeSelect} />
+            <SeasonTypeSelector />
           </SelectorWrapper>
           <DisplaySelectContainer role="tablist">
             <DisplaySelectItem

--- a/pages/[league]/schedule.tsx
+++ b/pages/[league]/schedule.tsx
@@ -42,7 +42,7 @@ function Schedule({ league, teamlist }: Props): JSX.Element {
   const [sprites, setSprites] = useState<{
     [index: string]: React.ComponentClass<any>;
   }>({});
-  const { games, isLoading } = useSchedule(league, filterSeasonType);
+  const { games, isLoading } = useSchedule(league);
   const scheduleContainerRef = useRef();
 
   useEffect(() => {

--- a/pages/[league]/standings.tsx
+++ b/pages/[league]/standings.tsx
@@ -11,7 +11,6 @@ import SeasonTypeSelector from '../../components/Selector/SeasonTypeSelector';
 import StandingsTable from '../../components/StandingsTable';
 import useStandings from '../../hooks/useStandings';
 import useWindowSize from '../../hooks/useWindowSize';
-import { SeasonType } from '../api/v1/schedule';
 import { Standings as StandingsData } from '../api/v1/standings';
 import { PlayoffsRound } from '../api/v1/standings/playoffs';
 
@@ -21,14 +20,13 @@ interface Props {
 
 function Standings({ league }: Props): JSX.Element {
   const [display, setDisplay] = useState('league');
-  const [seasonType, setSeasonType] = useState<SeasonType>('Regular Season');
+
   const [isPlayoffs, setIsPlayoffs] = useState(false);
-  const { data, isLoading } = useStandings(league, display, seasonType);
+  const { data, isLoading } = useStandings(league, display);
   const windowSize = useWindowSize();
 
   const onSeasonTypeSelect = (type) => {
     setIsPlayoffs(type === 'Playoffs');
-    setSeasonType(type);
   };
 
   const renderDoublePlayoffsBracket = useCallback(

--- a/pages/[league]/standings.tsx
+++ b/pages/[league]/standings.tsx
@@ -20,13 +20,14 @@ interface Props {
 
 function Standings({ league }: Props): JSX.Element {
   const [display, setDisplay] = useState('league');
-
+  const [, setSeasonType] = useState('regular');
   const [isPlayoffs, setIsPlayoffs] = useState(false);
   const { data, isLoading } = useStandings(league, display);
   const windowSize = useWindowSize();
 
   const onSeasonTypeSelect = (type) => {
     setIsPlayoffs(type === 'Playoffs');
+    setSeasonType(type);
   };
 
   const renderDoublePlayoffsBracket = useCallback(

--- a/pages/[league]/sths/index.tsx
+++ b/pages/[league]/sths/index.tsx
@@ -31,7 +31,6 @@ function LeagueHome({ league }: Props): JSX.Element {
     league,
     'skater',
     'points',
-    null,
     'all',
     5
   );
@@ -39,7 +38,6 @@ function LeagueHome({ league }: Props): JSX.Element {
     league,
     'skater',
     'goals',
-    null,
     'all',
     5
   );
@@ -47,7 +45,6 @@ function LeagueHome({ league }: Props): JSX.Element {
     league,
     'goalie',
     'wins',
-    null,
     'all',
     5
   );

--- a/pages/[league]/sths/individualLeaders.tsx
+++ b/pages/[league]/sths/individualLeaders.tsx
@@ -58,7 +58,6 @@ function Stats({ league }: Props): JSX.Element {
                 league={league}
                 playerType="skater"
                 stat={statId}
-                seasonType={'Regular Season'}
               />
             ))}
           </LeaderBoards>
@@ -70,7 +69,6 @@ function Stats({ league }: Props): JSX.Element {
                 league={league}
                 playerType="goalie"
                 stat={statId}
-                seasonType={'Regular Season'}
               />
             ))}
           </LeaderBoards>

--- a/pages/[league]/sths/leaders.tsx
+++ b/pages/[league]/sths/leaders.tsx
@@ -17,14 +17,10 @@ interface Props {
 }
 
 function PlayerPage({ league }: Props): JSX.Element {
-  const { ratings: skater, isLoading: isLoadingPlayers } = useSkaterStats(
-    league,
-    'Regular Season'
-  );
-  const { ratings: goalie, isLoading: isLoadingGoalies } = useGoalieStats(
-    league,
-    'Regular Season'
-  );
+  const { ratings: skater, isLoading: isLoadingPlayers } =
+    useSkaterStats(league);
+  const { ratings: goalie, isLoading: isLoadingGoalies } =
+    useGoalieStats(league);
 
   // get top 75 skaters in points
   const getSkater = () =>

--- a/pages/[league]/sths/scoring.tsx
+++ b/pages/[league]/sths/scoring.tsx
@@ -59,8 +59,8 @@ const STHSTeamLinks = [
 ];
 
 function ScoringPage({ league, teamlist }: Props): JSX.Element {
-  const { ratings: skaters } = useSkaterStats(league, 'Regular Season');
-  const { ratings: goalies } = useGoalieStats(league, 'Regular Season');
+  const { ratings: skaters } = useSkaterStats(league);
+  const { ratings: goalies } = useGoalieStats(league);
 
   const getSkater = (team) =>
     skaters

--- a/pages/[league]/sths/standing.tsx
+++ b/pages/[league]/sths/standing.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 function Standings({ league }: Props): JSX.Element {
   const [display, setDisplay] = useState('conference');
-  const { data, isLoading } = useStandings(league, display, 'Regular Season');
+  const { data, isLoading } = useStandings(league, display);
 
   return (
     <React.Fragment>

--- a/pages/[league]/team/[teamid].tsx
+++ b/pages/[league]/team/[teamid].tsx
@@ -60,11 +60,7 @@ function TeamPage({
   }
 
   const [filterSeasonType, setFilterSeasonType] = useState('Regular Season');
-  const { roster, isLoading } = useTeamRosterStats(
-    leaguename,
-    id,
-    filterSeasonType
-  );
+  const { roster, isLoading } = useTeamRosterStats(leaguename, id);
   const [display, setDisplay] = useState('stats');
 
   const getSkaters = () =>

--- a/utils/seasonType.ts
+++ b/utils/seasonType.ts
@@ -1,0 +1,7 @@
+export const getQuerySeasonType = (): string => {
+  if (typeof window === 'undefined') return '';
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const seasonType = urlParams.get('type') || '';
+  return seasonType.match(/\w+/) ? seasonType : '';
+};

--- a/utils/seasonType.ts
+++ b/utils/seasonType.ts
@@ -3,5 +3,5 @@ export const getQuerySeasonType = (): string => {
 
   const urlParams = new URLSearchParams(window.location.search);
   const seasonType = urlParams.get('type') || '';
-  return seasonType.match(/\w+/) ? seasonType : '';
+  return seasonType.match(/\w+/) ? seasonType : 'regular';
 };


### PR DESCRIPTION
This should make it so that once you set seasontype in on place on the site, it carries over to other parts of it. Plus you can now share links to pages with the seasontype included so the other user doesn't have to set it on their end!

This small change will make it so that we can start working towards more saved states in the url and you won't lose your place on the site again